### PR TITLE
Provide correct type when ssh key options are defined (#4)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,7 @@ jobs:
         beaker:
           - debian10-64
           - debian11-64
+          # - debian12-64 # not supported yet
     name: Acceptance / Image ${{ matrix.beaker }}
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Auto-detection expects name in format `{username}_{type}`.
  - `hostname` that will be part of exported resource (default: FQDN fact)
  - `separator` A character for user and key type auto-detection (default: `_`)
 
+Ssh key type depends on `ssh-keygen` version, see `ssh-keygen --help` for list of supported types on your system.
+
 
 ## Advanced configuration
 

--- a/lib/facter/pubkey.rb
+++ b/lib/facter/pubkey.rb
@@ -17,7 +17,9 @@ def pubkey_parse_ssh_key(str)
   }
   options = str[0, str.index(matched[0])].rstrip
   comment = matched[4]
-  key['options'] = options unless options.empty?
+  unless options.empty?
+    key['type'] = "#{options}#{matched[1]}"
+  end
   key['comment'] = comment unless comment.empty?
 
   key

--- a/spec/acceptance/ssh_spec.rb
+++ b/spec/acceptance/ssh_spec.rb
@@ -98,10 +98,7 @@ describe 'pubkey::ssh' do
         pubkey::ssh { 'john_ed25519-sk': }
       EOS
 
-      expect(apply_manifest(pp, {
-                             catch_failures: true,
-                              debug: false,
-                           }).exit_code).to 255
+      apply_manifest(pp, { expect_failures: true, })
       # missing FIDO (yubi) key
       # Key enrollment failed: invalid format
     end

--- a/spec/acceptance/ssh_spec.rb
+++ b/spec/acceptance/ssh_spec.rb
@@ -90,4 +90,48 @@ describe 'pubkey::ssh' do
       its(:stdout) { is_expected.to match "john:/home/john/.ssh/id_dsa.pub\n" }
     end
   end
+
+  context 'secure key' do
+    it 'generate ssh key' do
+      pp = <<~EOS
+        pubkey::ssh { 'john_ed25519-sk': }
+      EOS
+
+      expect(apply_manifest(pp, {
+                              catch_failures: false,
+                              debug: false,
+                            }).exit_code).to be_zero
+
+      expect(apply_manifest(pp, {
+                              catch_failures: false,
+                              debug: false,
+                            }).exit_code).to be_zero
+    end
+
+    describe file('/home/john/.ssh') do
+      it { is_expected.to be_directory }
+      it { is_expected.to be_readable.by('owner') }
+      it { is_expected.not_to be_readable.by('group') }
+      it { is_expected.not_to be_readable.by('others') }
+    end
+
+    describe file('/home/john/.ssh/id_ed25519_sk') do
+      it { is_expected.to be_file }
+      it { is_expected.to be_readable.by('owner') }
+      it { is_expected.not_to be_readable.by('group') }
+      it { is_expected.not_to be_readable.by('others') }
+    end
+
+    describe file('/home/john/.ssh/id_ed25519_sk.pub') do
+      it { is_expected.to be_file }
+      it { is_expected.to be_readable.by('owner') }
+      it { is_expected.to be_readable.by('group') }
+      it { is_expected.to be_readable.by('others') }
+    end
+
+    describe command('cat /var/cache/pubkey/exported_keys') do
+      its(:exit_status) { is_expected.to eq 0 }
+      its(:stdout) { is_expected.to match "john:/home/john/.ssh/id_ed25519_sk.pub\n" }
+    end
+  end
 end

--- a/spec/acceptance/ssh_spec.rb
+++ b/spec/acceptance/ssh_spec.rb
@@ -98,12 +98,10 @@ describe 'pubkey::ssh' do
         pubkey::ssh { 'john_ed25519-sk': }
       EOS
 
-      res = apply_manifest(pp, {
+      expect(apply_manifest(pp, {
                              catch_failures: true,
                               debug: false,
-                           })
-      expect(res.exit_code).to 255
-      expect(res.stderr.include?('Key enrollment failed: invalid format')).to true
+                           }).exit_code).to 255
       # missing FIDO (yubi) key
       # Key enrollment failed: invalid format
     end


### PR DESCRIPTION
Depending on ssh client version the supported key types might be following:

- `ssh-dss`
- `ssh-rsa`
- `ecdsa-sha2-nistp256`
- `ecdsa-sha2-nistp384` 
- `ecdsa-sha2-nistp521`
- `ssh-ed25519`
- `sk-ecdsa-sha2-nistp256@openssh.com` 
- `sk-ssh-ed25519@openssh.com`
- `ssh-rsa-cert-v01@openssh.com` 
- `ssh-ed25519-cert-v01@openssh.com`
- `ssh-dss-cert-v01@openssh.com`
- `ecdsa-sha2-nistp256-cert-v01@openssh.com` 
- `ecdsa-sha2-nistp384-cert-v01@openssh.com`
- `ecdsa-sha2-nistp521-cert-v01@openssh.com`

if prefix `sk-` is specified it should be returned as part of the type.