### PR TITLE
Fix username regex to include underscore

### DIFF
--- a/lib/facter/pubkey.rb
+++ b/lib/facter/pubkey.rb
@@ -32,7 +32,7 @@ Facter.add(:pubkey) do
     res = {}
     keys = '/var/cache/pubkey/exported_keys'
     if File.exist?(keys)
-      regexp = %r{([A-Za-z0-9-]+):(.*)}
+      regexp = %r{([A-Za-z0-9_-]+):(.*)}
       File.foreach(keys) do |line|
         if line.match? regexp
           m = line.match regexp


### PR DESCRIPTION
Posix username can include underscores : https://systemd.io/USER_NAMES/

This PR correct the regex in the facter code to include the underscore.