### PR TITLE
Support custom target_user (#7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,15 @@ The key will be exported as `alice_key@foo` (suffix is taken from the `hostname`
 Ssh_authorized_key <<| tag == "tag_users" |>>
 ```
 
+Customize `target_user` in order to store authorized key under different account than it was exported from.
+```
+pubkey::ssh { 'bob_ed25519':
+  user        => 'bob', # auto-detected from title
+  target_user => 'deploy', # user account under which authorized key will be stored
+  tags        => ['users'],
+}
+```
+
 All Puppet variables are documented in [REFERENCE.md](./REFERENCE.md).
 
 ## How does this work?

--- a/manifests/ssh.pp
+++ b/manifests/ssh.pp
@@ -18,6 +18,20 @@
 #
 # @example
 #   pubkey::ssh { 'john_rsa': }
+#
+# @example
+#  pubkey::ssh { 'johndoe':
+#    type    => 'ed25519',
+#    comment => 'johndoe_ed25519',
+#    tags    => ['users'],
+#  }
+#
+# @example
+#  pubkey::ssh { 'bob_ed25519':
+#    user        => 'bob', # auto-detected from title
+#    target_user => 'deploy', # user account under which authorized key will be stored
+#    tags        => ['users'],
+#  }
 define pubkey::ssh (
   Boolean                    $generate = true,
   Optional[String[1]]        $user = undef,

--- a/manifests/ssh.pp
+++ b/manifests/ssh.pp
@@ -3,7 +3,8 @@
 # Exports public ssh key to Puppetserver
 #
 # @param generate Whether missing key should be generated
-# @param user account name under which we will store the ssh key
+# @param user account name where ssh key is (optionally) generated and public key stored into exported resource
+# @param target_user account name under which we will store the authorized key (by default same as `user`)
 # @param type ssh key type one of: 'dsa', 'rsa', 'ecdsa', 'ed25519', 'ecdsa-sk', 'ed25519-sk'
 # @param home user's home directory, assuming .ssh is located in $HOME/.ssh
 # @param prefix custom key file prefix for the ssh key file (default: 'id')
@@ -20,6 +21,7 @@
 define pubkey::ssh (
   Boolean                    $generate = true,
   Optional[String[1]]        $user = undef,
+  Optional[String[1]]        $target_user = undef,
   Optional[Pubkey::Type]     $type = undef,
   Stdlib::AbsolutePath       $path = $facts['path'],
   Optional[Stdlib::UnixPath] $home = undef,
@@ -50,6 +52,11 @@ define pubkey::ssh (
       false => fail('unable to determine user')
     },
     default => $user
+  }
+
+  $_target_user = $target_user ? {
+    undef   => $_user,
+    default => $target_user,
   }
 
   $_home = $home ? {
@@ -107,7 +114,7 @@ define pubkey::ssh (
         if !empty($_key['type']) and !empty($_key['key']) {
           @@ssh_authorized_key { "${title}@${hostname}":
             ensure => present,
-            user   => $_user,
+            user   => $_target_user,
             type   => $_key['type'],
             key    => $_key['key'],
             tag    => $tags,


### PR DESCRIPTION
Support storing exported key under different account than it was generated from:
```
pubkey::ssh { 'alice_ed25519':
  target_user => 'bob',
  tags        => ['users'],
}
```
will read public ssh key from `/home/alice/.ssh/id_ed25519.pub` and store it to `/home/bob/.ssh/authorized_keys` on node where the resource is imported:
```
Ssh_authorized_key <<| tag == 'users' |>>
```
